### PR TITLE
Add System.Reactive aliases and Start/ToTask

### DIFF
--- a/src/Minimalist.Reactive.Tests/CoreRuntimeContractTests.cs
+++ b/src/Minimalist.Reactive.Tests/CoreRuntimeContractTests.cs
@@ -159,6 +159,14 @@ public class CoreRuntimeContractTests
     }
 
     [Test]
+    public void SchedulerDefaultAliasesExposeMigrationFriendlyNames()
+    {
+        Assert.Same(TaskPoolScheduler.Instance, TaskPoolScheduler.Default);
+        Assert.Same(TaskPoolScheduler.Default, Scheduler.Default);
+        Assert.Same(ThreadPoolScheduler.Instance, ThreadPoolScheduler.Instance);
+    }
+
+    [Test]
     public void NullableValueTimeStructsUseDeterministicNullHashCodes()
     {
         var timestamp = new DateTimeOffset(2026, 5, 24, 22, 52, 0, TimeSpan.Zero);

--- a/src/Minimalist.Reactive.Tests/FactoryOperatorContractTests.cs
+++ b/src/Minimalist.Reactive.Tests/FactoryOperatorContractTests.cs
@@ -224,6 +224,48 @@ public class FactoryOperatorContractTests
     }
 
     [Test]
+    public async Task SystemReactiveNamedAliasesCoverMigrationConvenienceSurface()
+    {
+        var values = new List<int>();
+        var sideEffects = new List<int>();
+        var recovered = new List<int>();
+        var observed = new List<int>();
+        var clock = new TestClock();
+        var source = new Signal<int>();
+
+        Signal.FromEnumerable(new[] { 2, 3 })
+            .StartWith(new[] { 0, 1 })
+            .Do(sideEffects.Add)
+            .AsObservable()
+            .Subscribe(values.Add);
+
+        Signal.Throw<int>(new InvalidOperationException("recover"))
+            .Catch(_ => Signal.Return(42))
+            .Subscribe(recovered.Add);
+
+        source.ObserveOn(clock).Subscribe(observed.Add);
+        source.OnNext(7);
+
+        Assert.Equal(new[] { 0, 1, 2, 3 }, values);
+        Assert.Equal((IEnumerable<int>)values, sideEffects);
+        Assert.Equal(new[] { 42 }, recovered);
+        Assert.Equal(0, observed.Count);
+
+        clock.Start();
+
+        Assert.Equal(new[] { 7 }, observed);
+
+        var converted = new[] { 4, 5 }.ToObservable();
+        var last = await converted.ToTask();
+        var first = await Signal.FromEnumerable(new[] { 9, 10 }).FirstAsync().ToTask();
+        var started = await Signal.Start(() => 11, Scheduler.CurrentThread).ToTask();
+
+        Assert.Equal(5, last);
+        Assert.Equal(9, first);
+        Assert.Equal(11, started);
+    }
+
+    [Test]
     public void BoundaryAndLatestOperatorsUseVirtualTimeAndCompletionSemantics()
     {
         var clock = new TestClock();

--- a/src/Minimalist.Reactive/Concurrency/Scheduler.cs
+++ b/src/Minimalist.Reactive/Concurrency/Scheduler.cs
@@ -19,6 +19,11 @@ public static partial class Scheduler
     /// </summary>
     public static ImmediateScheduler Immediate => ImmediateScheduler.Instance;
 
+    /// <summary>
+    /// Gets the default queueing scheduler for background work.
+    /// </summary>
+    public static IScheduler Default => TaskPoolScheduler.Default;
+
     internal static DateTimeOffset Now => DateTime.UtcNow;
 
     /// <summary>

--- a/src/Minimalist.Reactive/Concurrency/TaskPoolScheduler.cs
+++ b/src/Minimalist.Reactive/Concurrency/TaskPoolScheduler.cs
@@ -30,6 +30,11 @@ public sealed class TaskPoolScheduler : IScheduler
     public static TaskPoolScheduler Instance { get; } = new(Task.Factory);
 
     /// <summary>
+    /// Gets the default task-pool scheduler.
+    /// </summary>
+    public static TaskPoolScheduler Default => Instance;
+
+    /// <summary>
     /// Gets the scheduler's notion of current time.
     /// </summary>
     public DateTimeOffset Now => Scheduler.Now;

--- a/src/Minimalist.Reactive/Concurrency/ThreadPoolScheduler.cs
+++ b/src/Minimalist.Reactive/Concurrency/ThreadPoolScheduler.cs
@@ -14,7 +14,10 @@ namespace Minimalist.Reactive.Concurrency
     [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public sealed class ThreadPoolScheduler : IScheduler
     {
-        internal static readonly ThreadPoolScheduler Instance = new();
+        /// <summary>
+        /// Gets the shared thread-pool scheduler instance.
+        /// </summary>
+        public static readonly ThreadPoolScheduler Instance = new();
         internal static readonly object Gate = new();
         internal static readonly Dictionary<System.Threading.Timer, object> Timers = new();
 

--- a/src/Minimalist.Reactive/SignalOperatorParityMixins.cs
+++ b/src/Minimalist.Reactive/SignalOperatorParityMixins.cs
@@ -48,6 +48,135 @@ public static partial class LinqMixins
     }
 
     /// <summary>
+    /// Prepends a value before the source sequence using the System.Reactive operator name.
+    /// </summary>
+    public static IObservable<T> StartWith<T>(this IObservable<T> source, T value) => source.Prepend(value);
+
+    /// <summary>
+    /// Prepends values before the source sequence using the System.Reactive operator name.
+    /// </summary>
+    public static IObservable<T> StartWith<T>(this IObservable<T> source, params T[] values)
+    {
+        if (source == null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        if (values == null)
+        {
+            throw new ArgumentNullException(nameof(values));
+        }
+
+        return Signal.Concat(Signal.FromEnumerable(values), source);
+    }
+
+    /// <summary>
+    /// Prepends values before the source sequence using the System.Reactive operator name.
+    /// </summary>
+    public static IObservable<T> StartWith<T>(this IObservable<T> source, IEnumerable<T> values)
+    {
+        if (source == null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        if (values == null)
+        {
+            throw new ArgumentNullException(nameof(values));
+        }
+
+        return Signal.Concat(Signal.FromEnumerable(values), source);
+    }
+
+    /// <summary>
+    /// Returns the source as an observable. This is an identity adapter for BCL observable sources.
+    /// </summary>
+    public static IObservable<T> AsObservable<T>(this IObservable<T> source) => source ?? throw new ArgumentNullException(nameof(source));
+
+    /// <summary>
+    /// Converts an enumerable sequence to a Minimalist signal using the System.Reactive conversion name.
+    /// </summary>
+    public static IObservable<T> ToObservable<T>(this IEnumerable<T> values) => Signal.FromEnumerable(values);
+
+    /// <summary>
+    /// Schedules observer notifications on the supplied scheduler using the System.Reactive operator name.
+    /// </summary>
+    public static IObservable<T> ObserveOn<T>(this IObservable<T> source, IScheduler scheduler)
+    {
+        if (source == null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        if (scheduler == null)
+        {
+            throw new ArgumentNullException(nameof(scheduler));
+        }
+
+        return Signal.WitnessOn(source, scheduler);
+    }
+
+    /// <summary>
+    /// Alias for <see cref="DelayStart{T}(IObservable{T}, TimeSpan, IScheduler?)"/> using the System.Reactive operator name.
+    /// </summary>
+    public static IObservable<T> DelaySubscription<T>(this IObservable<T> source, TimeSpan dueTime, IScheduler? scheduler = null) =>
+        source.DelayStart(dueTime, scheduler);
+
+    /// <summary>
+    /// Runs a side effect for each source value using the System.Reactive operator name.
+    /// </summary>
+    public static IObservable<T> Do<T>(this IObservable<T> source, Action<T> onNext) => source.Tap(onNext);
+
+    /// <summary>
+    /// Runs side effects for source notifications using the System.Reactive operator name.
+    /// </summary>
+    public static IObservable<T> Do<T>(this IObservable<T> source, Action<T> onNext, Action<Exception> onError, Action onCompleted)
+    {
+        if (source == null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        if (onNext == null)
+        {
+            throw new ArgumentNullException(nameof(onNext));
+        }
+
+        if (onError == null)
+        {
+            throw new ArgumentNullException(nameof(onError));
+        }
+
+        if (onCompleted == null)
+        {
+            throw new ArgumentNullException(nameof(onCompleted));
+        }
+
+        return Signal.CreateSafe<T>(observer => source.Subscribe(
+            value =>
+            {
+                onNext(value);
+                observer.OnNext(value);
+            },
+            error =>
+            {
+                onError(error);
+                observer.OnError(error);
+            },
+            () =>
+            {
+                onCompleted();
+                observer.OnCompleted();
+            }));
+    }
+
+    /// <summary>
+    /// Alias for <see cref="Rescue{T}(IObservable{T}, Func{Exception, IObservable{T}})"/> using the System.Reactive operator name.
+    /// </summary>
+    public static IObservable<T> Catch<T>(this IObservable<T> source, Func<Exception, IObservable<T>> handler) =>
+        source.Rescue(handler);
+
+    /// <summary>
     /// Ignores all source values and only forwards terminal messages.
     /// </summary>
     public static IObservable<T> IgnoreValues<T>(this IObservable<T> source)
@@ -695,6 +824,74 @@ public static partial class LinqMixins
     /// Awaits the first source value, returning a default value when the source is empty.
     /// </summary>
     public static Task<T> FirstOrDefaultAsync<T>(this IObservable<T> source, T defaultValue = default!) => source.FirstOrDefaultCoreAsync(true, defaultValue);
+
+    /// <summary>
+    /// Awaits source completion and returns the last value produced by the source.
+    /// </summary>
+    public static Task<T> ToTask<T>(this IObservable<T> source) => source.ToTask(CancellationToken.None);
+
+    /// <summary>
+    /// Awaits source completion and returns the last value produced by the source.
+    /// </summary>
+    public static Task<T> ToTask<T>(this IObservable<T> source, CancellationToken cancellationToken)
+    {
+        if (source == null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        var completion = new TaskCompletionSource<T>();
+        var seen = false;
+        var last = default(T);
+        var subscription = default(IDisposable);
+        CancellationTokenRegistration cancellationRegistration = default;
+        if (cancellationToken.CanBeCanceled)
+        {
+            cancellationRegistration = cancellationToken.Register(() =>
+            {
+                subscription?.Dispose();
+                completion.TrySetCanceled(cancellationToken);
+            });
+        }
+
+        subscription = source.Subscribe(
+            value =>
+            {
+                seen = true;
+                last = value;
+            },
+            error =>
+            {
+                cancellationRegistration.Dispose();
+                subscription?.Dispose();
+                completion.TrySetException(error);
+            },
+            () =>
+            {
+                cancellationRegistration.Dispose();
+                subscription?.Dispose();
+                if (seen)
+                {
+                    completion.TrySetResult(last!);
+                }
+                else
+                {
+                    completion.TrySetException(new InvalidOperationException("The source completed without producing a value."));
+                }
+            });
+
+        if (completion.Task.IsCompleted)
+        {
+            subscription.Dispose();
+        }
+
+        return completion.Task;
+    }
+
+    /// <summary>
+    /// Identity helper that keeps source-compatible <c>FirstAsync().ToTask()</c> migrations compiling.
+    /// </summary>
+    public static Task<T> ToTask<T>(this Task<T> task) => task ?? throw new ArgumentNullException(nameof(task));
 
     /// <summary>
     /// Collects all values into an array task.

--- a/src/Minimalist.Reactive/Signals/Signal{Factories}.cs
+++ b/src/Minimalist.Reactive/Signals/Signal{Factories}.cs
@@ -237,6 +237,50 @@ public static partial class Signal
         });
     }
 
+    /// <summary>
+    /// Runs a function on the supplied scheduler and emits its result.
+    /// </summary>
+    public static IObservable<T> Start<T>(Func<T> function, IScheduler? scheduler = null)
+    {
+        if (function == null)
+        {
+            throw new ArgumentNullException(nameof(function));
+        }
+
+        scheduler ??= Scheduler.Default;
+        return CreateSafe<T>(observer => scheduler.Schedule(() =>
+        {
+            try
+            {
+                observer.OnNext(function());
+                observer.OnCompleted();
+            }
+            catch (Exception error)
+            {
+                observer.OnError(error);
+            }
+        }), scheduler == Scheduler.CurrentThread);
+    }
+
+    /// <summary>
+    /// Runs an action on the supplied scheduler and emits <see cref="RxVoid.Default"/> when it completes.
+    /// </summary>
+    public static IObservable<RxVoid> Start(Action action, IScheduler? scheduler = null)
+    {
+        if (action == null)
+        {
+            throw new ArgumentNullException(nameof(action));
+        }
+
+        return Start(
+            () =>
+            {
+                action();
+                return RxVoid.Default;
+            },
+            scheduler);
+    }
+
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
     /// <summary>
     /// Creates a signal from an async enumerable sequence and cancels enumeration when disposed.


### PR DESCRIPTION
Expose migration-friendly System.Reactive-style APIs and scheduler aliases. 
Adds many IObservable extension aliases (StartWith, AsObservable, ToObservable, ObserveOn, DelaySubscription, Do overloads, Catch) and identity/conversion helpers (ToTask, Task.ToTask). 
Adds Signal.Start overloads to run funcs/actions on a scheduler. 
Introduces Scheduler.Default and TaskPoolScheduler.Default, makes ThreadPoolScheduler.Instance public, and implements ToTask semantics with cancellation and completion behavior. 
Tests updated to assert the new aliases and conveniences.